### PR TITLE
conf/distro: switch to correct distro includes in cml-debug*

### DIFF
--- a/conf/distro/cml-debug-tiny.conf
+++ b/conf/distro/cml-debug-tiny.conf
@@ -1,4 +1,4 @@
-require conf/distro/gyroidos-cml.conf
+require conf/distro/cml-base.conf
 
 #gdb segfaults when building with musl in thud
 TCLIBC = "glibc"

--- a/conf/distro/cml-debug.conf
+++ b/conf/distro/cml-debug.conf
@@ -1,4 +1,4 @@
-require conf/distro/gyroidos-core.conf
+require conf/distro/core-ref.conf
 
 #gdb segfaults when building with musl in thud
 #TCLIBC = "glibc"


### PR DESCRIPTION
Distros gyroidos-{cml,core} where renamed to cml-base, core-ref. Use this here, too. We missed that in commit d7135879c0f5.

Fixes: d7135879c0f5 ("tree-wide: renamed trustx* recipes to gyroidos* and use new distros")