### PR TITLE
tree-wide: remove valgrind and gcc-sanitzers on riscv64

### DIFF
--- a/images/gyroidos-cml-initramfs.bbappend
+++ b/images/gyroidos-cml-initramfs.bbappend
@@ -16,3 +16,11 @@ PACKAGE_INSTALL += " \
 	gcc-sanitizers \
 	util-linux \
 "
+
+# valgrind release included in kirkstone does not support riscv64
+# remove this when we move to scarthgap"
+EXTENDED_PACKAGES:remove:riscv64 = "valgrind"
+
+# kirkstone does not include gcc sanitizers support for riscv64
+# remove this when we move to scarthgap"
+PACKAGE_INSTALL:remove:riscv64 = "gcc-sanitizers"

--- a/images/gyroidos-core.bbappend
+++ b/images/gyroidos-core.bbappend
@@ -12,3 +12,11 @@ PACKAGE_INSTALL += " \
 	gcc-sanitizers \
 	util-linux \
 "
+
+# valgrind release included in kirkstone does not support riscv64
+# remove this when we move to scarthgap"
+PACKAGE_INSTALL:remove:riscv64 = "valgrind"
+
+# kirkstone does not include gcc sanitizers support for riscv64
+# remove this when we move to scarthgap"
+PACKAGE_INSTALL:remove:riscv64 = "gcc-sanitizers"

--- a/recipes-gyroidos/cmld/cmld_%.bbappend
+++ b/recipes-gyroidos/cmld/cmld_%.bbappend
@@ -2,3 +2,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 DEPENDS += " gcc-sanitizers "
 IMAGE_INSTALL:append = " gcc-sanitizers "
+
+# kirkstone does not include gcc sanitizers support for riscv64
+DEPENDS:remove:riscv64 = "gcc-sanitizers"
+IMAGE_INSTALL:remove:riscv64 = " gcc-sanitizers "


### PR DESCRIPTION
The valgrind and gcc-sanitizers release included in kirkstone does not support riscv64. We remove them from CML as well as container images. We should revert this when we move to scarthgap.