### PR TITLE
tree-wide: remove valgrind and gcc-sanitzers on beaglev-fire

### DIFF
--- a/images/gyroidos-cml-initramfs.bbappend
+++ b/images/gyroidos-cml-initramfs.bbappend
@@ -20,7 +20,9 @@ PACKAGE_INSTALL += " \
 # valgrind release included in kirkstone does not support riscv64
 # remove this when we move to scarthgap"
 EXTENDED_PACKAGES:remove:riscv64 = "valgrind"
+EXTENDED_PACKAGES:remove:beaglev-fire = "valgrind"
 
 # kirkstone does not include gcc sanitizers support for riscv64
 # remove this when we move to scarthgap"
 PACKAGE_INSTALL:remove:riscv64 = "gcc-sanitizers"
+PACKAGE_INSTALL:remove:beaglev-fire = "gcc-sanitizers"

--- a/images/gyroidos-core.bbappend
+++ b/images/gyroidos-core.bbappend
@@ -16,7 +16,9 @@ PACKAGE_INSTALL += " \
 # valgrind release included in kirkstone does not support riscv64
 # remove this when we move to scarthgap"
 PACKAGE_INSTALL:remove:riscv64 = "valgrind"
+PACKAGE_INSTALL:remove:beaglev-fire = "valgrind"
 
 # kirkstone does not include gcc sanitizers support for riscv64
 # remove this when we move to scarthgap"
 PACKAGE_INSTALL:remove:riscv64 = "gcc-sanitizers"
+PACKAGE_INSTALL:remove:begalev-fire = "gcc-sanitizers"

--- a/recipes-gyroidos/cmld/cmld_%.bbappend
+++ b/recipes-gyroidos/cmld/cmld_%.bbappend
@@ -5,4 +5,6 @@ IMAGE_INSTALL:append = " gcc-sanitizers "
 
 # kirkstone does not include gcc sanitizers support for riscv64
 DEPENDS:remove:riscv64 = "gcc-sanitizers"
+DEPENDS:remove:beaglev-fire = "gcc-sanitizers"
 IMAGE_INSTALL:remove:riscv64 = " gcc-sanitizers "
+IMAGE_INSTALL:remove:beaglev-fire = " gcc-sanitizers "


### PR DESCRIPTION
The valgrind and gcc-sanitizers release included in kirkstone does not support begalev-fire. We remove them from CML as well as container images. We should revert this when we move to scarthgap.